### PR TITLE
chore: update renovate config to use github repository reference

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,3 @@
 {
-  "extends": ["@berlysia"]
+  "extends": ["github>berlysia/renovate-config"]
 }


### PR DESCRIPTION
Update deprecated `extends: @berlysia` to `extends: github>berlysia/renovate-config`

This change updates the Renovate configuration to use the GitHub repository reference instead of the deprecated npm package reference.